### PR TITLE
feat: implement M6 version history and approval workflow UI

### DIFF
--- a/src/components/AppSidebar.vue
+++ b/src/components/AppSidebar.vue
@@ -3,17 +3,21 @@ import { ref, computed, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/auth'
 import { useSubscriptionStore } from '@/stores/subscription'
+import { useApprovalsStore } from '@/stores/approvals'
 import PlanBadge from '@/components/PlanBadge.vue'
 
 const router = useRouter()
 const authStore = useAuthStore()
 const subscriptionStore = useSubscriptionStore()
+const approvalsStore = useApprovalsStore()
 const mobileOpen = ref(false)
 
 const planTier = computed(() => subscriptionStore.mySubscription?.plan.tier ?? 'FREE')
+const pendingCount = computed(() => approvalsStore.pendingReviews.length)
 
 onMounted(() => {
     subscriptionStore.fetchMySubscription().catch(() => {})
+    approvalsStore.fetchPendingReviews().catch(() => {})
 })
 
 function handleLogout(): void {
@@ -130,6 +134,38 @@ function closeMobile(): void {
                     />
                 </svg>
                 Documents
+            </router-link>
+
+            <router-link
+                to="/approvals/pending"
+                class="flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors focus-visible:ring-2 focus-visible:ring-indigo-500 focus-visible:outline-none"
+                :class="
+                    $route.path === '/approvals/pending'
+                        ? 'bg-gray-100 text-gray-900'
+                        : 'text-gray-500 hover:text-gray-900 hover:bg-gray-50'
+                "
+            >
+                <svg
+                    class="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    aria-hidden="true"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.75"
+                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                </svg>
+                Pending Approvals
+                <span
+                    v-if="pendingCount > 0"
+                    class="ml-auto text-xs font-semibold px-1.5 py-0.5 rounded-full bg-amber-100 text-amber-700"
+                >
+                    {{ pendingCount }}
+                </span>
             </router-link>
 
             <router-link

--- a/src/components/ApprovalBar.vue
+++ b/src/components/ApprovalBar.vue
@@ -1,0 +1,203 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { useApprovalsStore } from '@/stores/approvals'
+import { useAuthStore } from '@/stores/auth'
+import type { DocumentApprovalStatus } from '@/types/generation'
+import type { ApprovalDecision } from '@/types/approval'
+
+const props = defineProps<{
+    documentId: number
+    approvalStatus: DocumentApprovalStatus
+}>()
+
+const emit = defineEmits<{ viewRequest: []; statusChanged: [] }>()
+
+const approvalsStore = useApprovalsStore()
+const authStore = useAuthStore()
+
+const reviewComment = ref('')
+const isSubmitting = ref(false)
+const showReviewInput = ref(false)
+const pendingDecision = ref<ApprovalDecision | null>(null)
+
+const latestRequest = computed(
+    () => approvalsStore.requests[approvalsStore.requests.length - 1] ?? null
+)
+
+const pendingReviewCount = computed(
+    () => latestRequest.value?.reviews.filter((r) => r.decision === null).length ?? 0
+)
+
+const isRequester = computed(
+    () => latestRequest.value?.requestedBy.id === authStore.user?.id
+)
+
+const myPendingReview = computed(() => {
+    if (!latestRequest.value) return null
+    return (
+        approvalsStore.pendingReviews.find((r) => r.id === latestRequest.value!.id) ??
+        null
+    )
+})
+
+async function handleWithdraw(): Promise<void> {
+    if (!latestRequest.value) return
+    await approvalsStore.withdraw(props.documentId, latestRequest.value.id)
+    emit('statusChanged')
+}
+
+function startReview(decision: ApprovalDecision): void {
+    pendingDecision.value = decision
+    showReviewInput.value = true
+}
+
+async function submitReview(): Promise<void> {
+    if (!latestRequest.value || !pendingDecision.value) return
+    isSubmitting.value = true
+    try {
+        await approvalsStore.submitReview(props.documentId, latestRequest.value.id, {
+            decision: pendingDecision.value,
+            comment: reviewComment.value.trim() || undefined
+        })
+        showReviewInput.value = false
+        reviewComment.value = ''
+        pendingDecision.value = null
+        emit('statusChanged')
+    } finally {
+        isSubmitting.value = false
+    }
+}
+</script>
+
+<template>
+    <!-- PENDING_APPROVAL bar -->
+    <div
+        v-if="props.approvalStatus === 'PENDING_APPROVAL'"
+        class="bg-amber-50 border-b border-amber-200 px-4 py-2.5 shrink-0"
+    >
+        <div class="max-w-7xl mx-auto flex items-center justify-between flex-wrap gap-2">
+            <div>
+                <span class="text-sm font-medium text-amber-800">
+                    Awaiting approval
+                </span>
+                <span v-if="pendingReviewCount > 0" class="text-sm text-amber-600 ml-1">
+                    from {{ pendingReviewCount }} reviewer(s)
+                </span>
+            </div>
+            <div class="flex items-center gap-2">
+                <!-- Reviewer actions -->
+                <template v-if="myPendingReview && !showReviewInput">
+                    <span class="text-xs text-amber-700 mr-1">
+                        Your review is requested
+                    </span>
+                    <button
+                        @click="startReview('APPROVED')"
+                        class="px-3 py-1 rounded-lg bg-green-600 text-white text-xs font-medium hover:bg-green-700 transition-colors"
+                    >
+                        Approve
+                    </button>
+                    <button
+                        @click="startReview('REJECTED')"
+                        class="px-3 py-1 rounded-lg bg-red-600 text-white text-xs font-medium hover:bg-red-700 transition-colors"
+                    >
+                        Reject
+                    </button>
+                </template>
+                <!-- Requester withdraw -->
+                <button
+                    v-if="isRequester"
+                    @click="handleWithdraw"
+                    class="px-3 py-1 rounded-lg border border-amber-300 text-amber-700 text-xs font-medium hover:bg-amber-100 transition-colors"
+                >
+                    Withdraw
+                </button>
+            </div>
+        </div>
+        <!-- Inline review comment -->
+        <div v-if="showReviewInput" class="max-w-7xl mx-auto mt-2 flex items-start gap-2">
+            <input
+                v-model="reviewComment"
+                type="text"
+                placeholder="Add a comment (optional)…"
+                class="flex-1 rounded-lg border border-amber-300 px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+            />
+            <button
+                @click="submitReview"
+                :disabled="isSubmitting"
+                class="px-3 py-1.5 rounded-lg bg-gray-900 text-white text-xs font-medium hover:bg-gray-700 transition-colors disabled:opacity-50"
+            >
+                {{
+                    isSubmitting
+                        ? 'Submitting…'
+                        : pendingDecision === 'APPROVED'
+                          ? 'Confirm Approve'
+                          : 'Confirm Reject'
+                }}
+            </button>
+            <button
+                @click="showReviewInput = false"
+                class="text-xs text-amber-600 hover:text-amber-900 px-2"
+            >
+                Cancel
+            </button>
+        </div>
+    </div>
+
+    <!-- APPROVED bar -->
+    <div
+        v-else-if="props.approvalStatus === 'APPROVED'"
+        class="bg-green-50 border-b border-green-200 px-4 py-2.5 shrink-0"
+    >
+        <div class="max-w-7xl mx-auto flex items-center gap-2">
+            <svg
+                class="w-4 h-4 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M5 13l4 4L19 7"
+                />
+            </svg>
+            <span class="text-sm font-medium text-green-800">Approved</span>
+            <button
+                @click="emit('viewRequest')"
+                class="text-xs text-green-600 hover:underline ml-1"
+            >
+                View details
+            </button>
+        </div>
+    </div>
+
+    <!-- REJECTED bar -->
+    <div
+        v-else-if="props.approvalStatus === 'REJECTED'"
+        class="bg-red-50 border-b border-red-200 px-4 py-2.5 shrink-0"
+    >
+        <div class="max-w-7xl mx-auto flex items-center gap-2">
+            <svg
+                class="w-4 h-4 text-red-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+            >
+                <path
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M6 18L18 6M6 6l12 12"
+                />
+            </svg>
+            <span class="text-sm font-medium text-red-800">Rejected</span>
+            <button
+                @click="emit('viewRequest')"
+                class="text-xs text-red-600 hover:underline ml-1"
+            >
+                View feedback
+            </button>
+        </div>
+    </div>
+</template>

--- a/src/components/ApprovalRequestModal.vue
+++ b/src/components/ApprovalRequestModal.vue
@@ -1,0 +1,162 @@
+<script setup lang="ts">
+import type { ApprovalRequest, ApprovalDecision } from '@/types/approval'
+
+const props = defineProps<{ request: ApprovalRequest }>()
+const emit = defineEmits<{ close: [] }>()
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+    })
+}
+
+const decisionLabel: Record<ApprovalDecision, string> = {
+    APPROVED: 'Approved',
+    REJECTED: 'Rejected'
+}
+
+const decisionClass: Record<ApprovalDecision, string> = {
+    APPROVED: 'bg-green-100 text-green-700',
+    REJECTED: 'bg-red-100 text-red-700'
+}
+
+const statusClass: Record<string, string> = {
+    PENDING: 'bg-amber-100 text-amber-700',
+    APPROVED: 'bg-green-100 text-green-700',
+    REJECTED: 'bg-red-100 text-red-700',
+    WITHDRAWN: 'bg-gray-100 text-gray-600'
+}
+</script>
+
+<template>
+    <div
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        @click.self="emit('close')"
+    >
+        <div
+            class="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 flex flex-col max-h-[80vh]"
+        >
+            <!-- Header -->
+            <div
+                class="flex items-start justify-between p-5 border-b border-gray-100 shrink-0"
+            >
+                <div>
+                    <div class="flex items-center gap-2">
+                        <span class="text-sm font-semibold text-gray-900">
+                            Approval Request
+                        </span>
+                        <span
+                            class="text-xs font-medium px-2 py-0.5 rounded-full"
+                            :class="statusClass[props.request.status]"
+                        >
+                            {{ props.request.status.replace('_', ' ') }}
+                        </span>
+                    </div>
+                    <p class="text-xs text-gray-400 mt-0.5">
+                        Requested by {{ props.request.requestedBy.name }} &middot;
+                        {{ formatDate(props.request.createdAt) }}
+                    </p>
+                </div>
+                <button
+                    @click="emit('close')"
+                    class="text-gray-400 hover:text-gray-700 transition-colors"
+                    aria-label="Close"
+                >
+                    <svg
+                        class="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Body -->
+            <div class="flex-1 overflow-y-auto p-5 space-y-4">
+                <!-- Message -->
+                <div v-if="props.request.message" class="bg-gray-50 rounded-xl px-4 py-3">
+                    <p class="text-xs font-medium text-gray-500 mb-1">Message</p>
+                    <p class="text-sm text-gray-800">
+                        {{ props.request.message }}
+                    </p>
+                </div>
+
+                <!-- Reviews -->
+                <div>
+                    <p class="text-xs font-medium text-gray-500 mb-2">
+                        Reviews
+                        <span class="text-gray-400 font-normal ml-1">
+                            ({{ props.request.reviews.length }})
+                        </span>
+                    </p>
+
+                    <div
+                        v-if="props.request.reviews.length === 0"
+                        class="text-xs text-gray-400 text-center py-4"
+                    >
+                        No reviews yet.
+                    </div>
+
+                    <div class="space-y-3">
+                        <div
+                            v-for="review in props.request.reviews"
+                            :key="review.id"
+                            class="flex items-start gap-3"
+                        >
+                            <div
+                                class="w-7 h-7 rounded-full bg-gray-200 flex items-center justify-center shrink-0"
+                            >
+                                <span class="text-xs font-medium text-gray-600">
+                                    {{ review.reviewer.name.charAt(0).toUpperCase() }}
+                                </span>
+                            </div>
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-baseline gap-2">
+                                    <span class="text-xs font-semibold text-gray-800">
+                                        {{ review.reviewer.name }}
+                                    </span>
+                                    <span
+                                        class="text-xs font-medium px-1.5 py-0.5 rounded-full"
+                                        :class="decisionClass[review.decision]"
+                                    >
+                                        {{ decisionLabel[review.decision] }}
+                                    </span>
+                                    <span class="text-xs text-gray-400">
+                                        {{ formatDate(review.reviewedAt) }}
+                                    </span>
+                                </div>
+                                <p
+                                    v-if="review.comment"
+                                    class="text-xs text-gray-600 mt-0.5"
+                                >
+                                    {{ review.comment }}
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex justify-end p-5 border-t border-gray-100 shrink-0">
+                <button
+                    @click="emit('close')"
+                    class="px-4 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                >
+                    Close
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/components/RequestApprovalModal.vue
+++ b/src/components/RequestApprovalModal.vue
@@ -1,0 +1,187 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useApprovalsStore } from '@/stores/approvals'
+
+const props = defineProps<{ documentId: number }>()
+const emit = defineEmits<{ close: []; submitted: [] }>()
+
+const approvalsStore = useApprovalsStore()
+
+const emailInput = ref('')
+const emails = ref<string[]>([])
+const message = ref('')
+const errorMsg = ref('')
+const isSubmitting = ref(false)
+
+function addEmail(): void {
+    const val = emailInput.value.trim()
+    if (!val) return
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val)) {
+        errorMsg.value = 'Please enter a valid email address.'
+        return
+    }
+    if (emails.value.includes(val)) {
+        errorMsg.value = 'Email already added.'
+        return
+    }
+    emails.value.push(val)
+    emailInput.value = ''
+    errorMsg.value = ''
+}
+
+function removeEmail(email: string): void {
+    emails.value = emails.value.filter((e) => e !== email)
+}
+
+function handleEmailKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Enter') {
+        event.preventDefault()
+        addEmail()
+    }
+}
+
+async function handleSubmit(): Promise<void> {
+    if (emails.value.length === 0) {
+        errorMsg.value = 'Add at least one reviewer email.'
+        return
+    }
+    isSubmitting.value = true
+    errorMsg.value = ''
+    try {
+        await approvalsStore.createRequest(props.documentId, {
+            reviewerEmails: emails.value,
+            message: message.value.trim() || undefined
+        })
+        emit('submitted')
+        emit('close')
+    } catch {
+        errorMsg.value = 'Failed to send approval request. Please try again.'
+    } finally {
+        isSubmitting.value = false
+    }
+}
+</script>
+
+<template>
+    <div
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        @click.self="emit('close')"
+    >
+        <div class="bg-white rounded-2xl shadow-xl w-full max-w-md mx-4">
+            <!-- Header -->
+            <div class="flex items-center justify-between p-5 border-b border-gray-100">
+                <span class="text-sm font-semibold text-gray-900">
+                    Request Approval
+                </span>
+                <button
+                    @click="emit('close')"
+                    class="text-gray-400 hover:text-gray-700 transition-colors"
+                    aria-label="Close"
+                >
+                    <svg
+                        class="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Body -->
+            <div class="p-5 space-y-4">
+                <!-- Email input -->
+                <div>
+                    <label class="block text-xs font-medium text-gray-600 mb-1">
+                        Reviewer emails
+                        <span class="text-red-400 ml-0.5">*</span>
+                    </label>
+                    <!-- Chips -->
+                    <div v-if="emails.length > 0" class="flex flex-wrap gap-1.5 mb-2">
+                        <span
+                            v-for="email in emails"
+                            :key="email"
+                            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-gray-100 text-xs text-gray-700"
+                        >
+                            {{ email }}
+                            <button
+                                @click="removeEmail(email)"
+                                class="text-gray-400 hover:text-gray-700"
+                                :aria-label="`Remove ${email}`"
+                            >
+                                <svg
+                                    class="w-3 h-3"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                >
+                                    <path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        stroke-width="2"
+                                        d="M6 18L18 6M6 6l12 12"
+                                    />
+                                </svg>
+                            </button>
+                        </span>
+                    </div>
+                    <div class="flex gap-2">
+                        <input
+                            v-model="emailInput"
+                            type="email"
+                            placeholder="reviewer@example.com"
+                            class="flex-1 rounded-lg border border-gray-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                            @keydown="handleEmailKeydown"
+                        />
+                        <button
+                            @click="addEmail"
+                            class="px-3 py-2 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                        >
+                            Add
+                        </button>
+                    </div>
+                    <p v-if="errorMsg" class="mt-1 text-xs text-red-500">
+                        {{ errorMsg }}
+                    </p>
+                </div>
+
+                <!-- Message -->
+                <div>
+                    <label class="block text-xs font-medium text-gray-600 mb-1">
+                        Message
+                        <span class="text-gray-400 ml-1">(optional)</span>
+                    </label>
+                    <textarea
+                        v-model="message"
+                        rows="3"
+                        placeholder="Add context for the reviewers…"
+                        class="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-transparent"
+                    />
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex items-center justify-end gap-2 p-5 border-t border-gray-100">
+                <button
+                    @click="emit('close')"
+                    class="px-4 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                >
+                    Cancel
+                </button>
+                <button
+                    @click="handleSubmit"
+                    :disabled="isSubmitting || emails.length === 0"
+                    class="px-4 py-1.5 rounded-lg bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                    {{ isSubmitting ? 'Sending…' : 'Send Request' }}
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/components/VersionCompareModal.vue
+++ b/src/components/VersionCompareModal.vue
@@ -1,0 +1,145 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { DocumentVersion } from '@/types/document'
+
+const props = defineProps<{
+    versionA: DocumentVersion
+    versionB: DocumentVersion
+}>()
+
+const emit = defineEmits<{ close: [] }>()
+
+const allKeys = computed(() => {
+    const keys = new Set([
+        ...Object.keys(props.versionA.fieldValues),
+        ...Object.keys(props.versionB.fieldValues)
+    ])
+    return Array.from(keys)
+})
+
+function isDifferent(key: string): boolean {
+    return props.versionA.fieldValues[key] !== props.versionB.fieldValues[key]
+}
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    })
+}
+</script>
+
+<template>
+    <div
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        @click.self="emit('close')"
+    >
+        <div
+            class="bg-white rounded-2xl shadow-xl w-full max-w-3xl mx-4 flex flex-col max-h-[85vh]"
+        >
+            <!-- Header -->
+            <div
+                class="flex items-center justify-between p-5 border-b border-gray-100 shrink-0"
+            >
+                <span class="text-sm font-semibold text-gray-900">
+                    Compare Versions
+                </span>
+                <button
+                    @click="emit('close')"
+                    class="text-gray-400 hover:text-gray-700 transition-colors"
+                    aria-label="Close"
+                >
+                    <svg
+                        class="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Column headers -->
+            <div
+                class="grid grid-cols-[1fr_1fr] gap-4 px-5 py-3 border-b border-gray-100 bg-gray-50 shrink-0"
+            >
+                <div>
+                    <span
+                        class="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-200 text-gray-700"
+                    >
+                        v{{ props.versionA.versionNumber }}
+                    </span>
+                    <span class="text-xs text-gray-400 ml-2">
+                        {{ formatDate(props.versionA.createdAt) }}
+                    </span>
+                </div>
+                <div>
+                    <span
+                        class="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-200 text-gray-700"
+                    >
+                        v{{ props.versionB.versionNumber }}
+                    </span>
+                    <span class="text-xs text-gray-400 ml-2">
+                        {{ formatDate(props.versionB.createdAt) }}
+                    </span>
+                </div>
+            </div>
+
+            <!-- Comparison rows -->
+            <div class="flex-1 overflow-y-auto p-5">
+                <div
+                    v-if="allKeys.length === 0"
+                    class="text-xs text-gray-400 text-center py-8"
+                >
+                    No fields to compare.
+                </div>
+                <div v-else class="space-y-2">
+                    <div v-for="key in allKeys" :key="key">
+                        <p class="text-xs font-medium text-gray-500 mb-1">
+                            {{ key }}
+                        </p>
+                        <div class="grid grid-cols-[1fr_1fr] gap-4">
+                            <div
+                                class="rounded-lg px-3 py-2 text-sm"
+                                :class="
+                                    isDifferent(key)
+                                        ? 'bg-yellow-50 text-yellow-900'
+                                        : 'bg-gray-50 text-gray-900'
+                                "
+                            >
+                                {{ props.versionA.fieldValues[key] || '—' }}
+                            </div>
+                            <div
+                                class="rounded-lg px-3 py-2 text-sm"
+                                :class="
+                                    isDifferent(key)
+                                        ? 'bg-yellow-50 text-yellow-900'
+                                        : 'bg-gray-50 text-gray-900'
+                                "
+                            >
+                                {{ props.versionB.fieldValues[key] || '—' }}
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div class="flex justify-end p-5 border-t border-gray-100 shrink-0">
+                <button
+                    @click="emit('close')"
+                    class="px-4 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                >
+                    Close
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/components/VersionHistoryPanel.vue
+++ b/src/components/VersionHistoryPanel.vue
@@ -1,0 +1,223 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { useDocumentsStore } from '@/stores/documents'
+import VersionPreviewModal from '@/components/VersionPreviewModal.vue'
+import VersionCompareModal from '@/components/VersionCompareModal.vue'
+import type { DocumentVersion } from '@/types/document'
+
+const props = defineProps<{ documentId: number }>()
+
+const documentsStore = useDocumentsStore()
+
+const previewVersion = ref<DocumentVersion | null>(null)
+const compareSelections = ref<number[]>([])
+const showCompare = ref(false)
+const confirmRestoreId = ref<number | null>(null)
+const isRestoring = ref(false)
+
+const versions = computed(() => documentsStore.versions)
+const loading = computed(() => documentsStore.versionsLoading)
+
+const latestVersionNumber = computed(() => {
+    if (versions.value.length === 0) return 0
+    return Math.max(...versions.value.map((v) => v.versionNumber))
+})
+
+const compareVersionA = computed(
+    () => versions.value.find((v) => v.id === compareSelections.value[0]) ?? null
+)
+const compareVersionB = computed(
+    () => versions.value.find((v) => v.id === compareSelections.value[1]) ?? null
+)
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+    })
+}
+
+function toggleCompareSelection(id: number): void {
+    const idx = compareSelections.value.indexOf(id)
+    if (idx !== -1) {
+        compareSelections.value.splice(idx, 1)
+    } else if (compareSelections.value.length < 2) {
+        compareSelections.value.push(id)
+    }
+}
+
+async function handleRestore(versionId: number): Promise<void> {
+    isRestoring.value = true
+    try {
+        await documentsStore.restoreVersion(props.documentId, versionId)
+        confirmRestoreId.value = null
+        previewVersion.value = null
+    } finally {
+        isRestoring.value = false
+    }
+}
+
+onMounted(() => documentsStore.fetchVersions(props.documentId))
+</script>
+
+<template>
+    <div class="w-72 shrink-0 bg-white border-l border-gray-100 flex flex-col h-full">
+        <!-- Panel header -->
+        <div
+            class="h-12 flex items-center justify-between px-4 border-b border-gray-100 shrink-0"
+        >
+            <span class="text-sm font-semibold text-gray-800"> Version History </span>
+            <button
+                v-if="compareSelections.length === 2"
+                @click="showCompare = true"
+                class="text-xs font-medium text-indigo-600 hover:text-indigo-800 transition-colors"
+            >
+                Compare
+            </button>
+        </div>
+
+        <!-- Compare hint -->
+        <div
+            v-if="compareSelections.length > 0"
+            class="px-4 py-2 text-xs text-gray-500 bg-gray-50 border-b border-gray-100 shrink-0"
+        >
+            {{ compareSelections.length }}/2 selected for compare
+        </div>
+
+        <!-- Versions list -->
+        <div class="flex-1 overflow-y-auto p-3 space-y-2">
+            <div v-if="loading" class="flex flex-col gap-2">
+                <div
+                    v-for="i in 4"
+                    :key="i"
+                    class="h-16 bg-gray-50 rounded-lg animate-pulse"
+                />
+            </div>
+
+            <div
+                v-else-if="versions.length === 0"
+                class="text-xs text-gray-400 text-center py-8"
+            >
+                No versions yet.
+            </div>
+
+            <div
+                v-for="version in versions"
+                :key="version.id"
+                class="rounded-xl border p-3 transition-colors"
+                :class="
+                    compareSelections.includes(version.id)
+                        ? 'border-indigo-300 bg-indigo-50'
+                        : 'border-gray-100 bg-white hover:border-gray-200'
+                "
+            >
+                <div class="flex items-start gap-2">
+                    <!-- Compare checkbox -->
+                    <input
+                        type="checkbox"
+                        :checked="compareSelections.includes(version.id)"
+                        :disabled="
+                            !compareSelections.includes(version.id) &&
+                            compareSelections.length >= 2
+                        "
+                        @change="toggleCompareSelection(version.id)"
+                        class="mt-0.5 w-3.5 h-3.5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                    />
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-center gap-1.5 flex-wrap">
+                            <span
+                                class="text-xs font-semibold px-1.5 py-0.5 rounded-full bg-gray-100 text-gray-700"
+                            >
+                                v{{ version.versionNumber }}
+                            </span>
+                            <span
+                                v-if="version.versionNumber === latestVersionNumber"
+                                class="text-xs px-1.5 py-0.5 rounded-full bg-green-100 text-green-700 font-medium"
+                            >
+                                current
+                            </span>
+                        </div>
+                        <p
+                            v-if="version.changeNote"
+                            class="text-xs text-gray-700 mt-1 truncate"
+                        >
+                            {{ version.changeNote }}
+                        </p>
+                        <p class="text-xs text-gray-400 mt-0.5">
+                            {{ version.createdBy.name }} &middot;
+                            {{ formatDate(version.createdAt) }}
+                        </p>
+                        <!-- Actions -->
+                        <div class="flex items-center gap-2 mt-2">
+                            <button
+                                @click="previewVersion = version"
+                                class="text-xs text-gray-500 hover:text-gray-900 font-medium transition-colors"
+                            >
+                                View
+                            </button>
+                            <template
+                                v-if="version.versionNumber !== latestVersionNumber"
+                            >
+                                <span class="text-gray-200">|</span>
+                                <button
+                                    @click="confirmRestoreId = version.id"
+                                    class="text-xs text-gray-500 hover:text-gray-900 font-medium transition-colors"
+                                >
+                                    Restore
+                                </button>
+                            </template>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Inline restore confirm -->
+                <div
+                    v-if="confirmRestoreId === version.id"
+                    class="mt-2 pt-2 border-t border-gray-100"
+                >
+                    <p class="text-xs text-gray-600 mb-2">
+                        Restore to v{{ version.versionNumber }}?
+                    </p>
+                    <div class="flex gap-2">
+                        <button
+                            @click="handleRestore(version.id)"
+                            :disabled="isRestoring"
+                            class="text-xs font-medium text-white bg-gray-900 px-2.5 py-1 rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50"
+                        >
+                            {{ isRestoring ? 'Restoring…' : 'Confirm' }}
+                        </button>
+                        <button
+                            @click="confirmRestoreId = null"
+                            class="text-xs text-gray-400 hover:text-gray-700"
+                        >
+                            Cancel
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- Version Preview Modal -->
+    <VersionPreviewModal
+        v-if="previewVersion"
+        :version="previewVersion"
+        @close="previewVersion = null"
+        @restore="
+            (id) => {
+                previewVersion = null
+                confirmRestoreId = id
+            }
+        "
+    />
+
+    <!-- Version Compare Modal -->
+    <VersionCompareModal
+        v-if="showCompare && compareVersionA && compareVersionB"
+        :version-a="compareVersionA"
+        :version-b="compareVersionB"
+        @close="showCompare = false"
+    />
+</template>

--- a/src/components/VersionPreviewModal.vue
+++ b/src/components/VersionPreviewModal.vue
@@ -1,0 +1,122 @@
+<script setup lang="ts">
+import type { DocumentVersion } from '@/types/document'
+
+const props = defineProps<{
+    version: DocumentVersion
+}>()
+
+const emit = defineEmits<{
+    close: []
+    restore: [versionId: number]
+}>()
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit'
+    })
+}
+</script>
+
+<template>
+    <div
+        class="fixed inset-0 bg-black/30 flex items-center justify-center z-50"
+        @click.self="emit('close')"
+    >
+        <div
+            class="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 flex flex-col max-h-[80vh]"
+        >
+            <!-- Header -->
+            <div
+                class="flex items-start justify-between p-5 border-b border-gray-100 shrink-0"
+            >
+                <div>
+                    <div class="flex items-center gap-2">
+                        <span
+                            class="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700"
+                        >
+                            v{{ props.version.versionNumber }}
+                        </span>
+                        <span class="text-sm font-semibold text-gray-900">
+                            Version Preview
+                        </span>
+                    </div>
+                    <p v-if="props.version.changeNote" class="text-xs text-gray-500 mt-1">
+                        {{ props.version.changeNote }}
+                    </p>
+                    <p class="text-xs text-gray-400 mt-0.5">
+                        By {{ props.version.createdBy.name }} &middot;
+                        {{ formatDate(props.version.createdAt) }}
+                    </p>
+                </div>
+                <button
+                    @click="emit('close')"
+                    class="text-gray-400 hover:text-gray-700 transition-colors"
+                    aria-label="Close"
+                >
+                    <svg
+                        class="w-5 h-5"
+                        fill="none"
+                        viewBox="0 0 24 24"
+                        stroke="currentColor"
+                    >
+                        <path
+                            stroke-linecap="round"
+                            stroke-linejoin="round"
+                            stroke-width="2"
+                            d="M6 18L18 6M6 6l12 12"
+                        />
+                    </svg>
+                </button>
+            </div>
+
+            <!-- Field values -->
+            <div class="flex-1 overflow-y-auto p-5">
+                <div
+                    v-if="Object.keys(props.version.fieldValues).length === 0"
+                    class="text-xs text-gray-400 text-center py-8"
+                >
+                    No field values recorded for this version.
+                </div>
+                <div v-else class="space-y-3">
+                    <div
+                        v-for="(value, key) in props.version.fieldValues"
+                        :key="key"
+                        class="flex items-baseline gap-3 py-2 border-b border-gray-50 last:border-0"
+                    >
+                        <span class="text-xs font-medium text-gray-500 w-32 shrink-0">
+                            {{ key }}
+                        </span>
+                        <span
+                            class="text-sm text-gray-900"
+                            :class="{ 'text-gray-300 italic': !value }"
+                        >
+                            {{ value || '—' }}
+                        </span>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Footer -->
+            <div
+                class="flex items-center justify-end gap-2 p-5 border-t border-gray-100 shrink-0"
+            >
+                <button
+                    @click="emit('close')"
+                    class="px-4 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                >
+                    Close
+                </button>
+                <button
+                    @click="emit('restore', props.version.id)"
+                    class="px-4 py-1.5 rounded-lg bg-gray-900 text-white text-sm font-medium hover:bg-gray-700 transition-colors"
+                >
+                    Restore this version
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -113,6 +113,12 @@ const routes: RouteRecordRaw[] = [
         component: () => import('@/views/intake/PublicIntakeFormView.vue')
     },
     {
+        path: '/approvals/pending',
+        name: 'pending-approvals',
+        component: () => import('@/views/approvals/PendingApprovalsView.vue'),
+        meta: { requiresAuth: true }
+    },
+    {
         path: '/clause-library',
         name: 'clause-library',
         component: () => import('@/views/clauses/ClauseLibraryView.vue'),

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -34,6 +34,8 @@ import type {
     OrgRole,
     BillingCycle
 } from '@/types/subscription'
+import type { DocumentVersion } from '@/types/document'
+import type { ApprovalRequest, CreateApprovalRequestDTO, SubmitReviewDTO } from '@/types/approval'
 
 const api = axios.create({
     baseURL: '/api',
@@ -177,6 +179,32 @@ export const organizationApi = {
     removeMember: (orgId: number, userId: number) => api.delete(`/organizations/${orgId}/members/${userId}`),
     updateMemberRole: (orgId: number, userId: number, role: OrgRole) =>
         api.put<OrganizationMember>(`/organizations/${orgId}/members/${userId}/role`, { role })
+}
+
+// ── Document Versions (authenticated) ────────────────────────────────────────
+
+export const documentsApi = {
+    getVersions: (documentId: number) => api.get<DocumentVersion[]>(`/documents/${documentId}/versions`),
+    getVersion: (documentId: number, versionId: number) =>
+        api.get<DocumentVersion>(`/documents/${documentId}/versions/${versionId}`),
+    compareVersions: (documentId: number, versionIdA: number, versionIdB: number) =>
+        api.get(`/documents/${documentId}/versions/compare`, { params: { a: versionIdA, b: versionIdB } }),
+    restoreVersion: (documentId: number, versionId: number) =>
+        api.post(`/documents/${documentId}/versions/${versionId}/restore`)
+}
+
+// ── Approvals (authenticated) ─────────────────────────────────────────────────
+
+export const approvalsApi = {
+    getForDocument: (documentId: number) => api.get<ApprovalRequest[]>(`/documents/${documentId}/approvals`),
+    create: (documentId: number, data: CreateApprovalRequestDTO) =>
+        api.post<ApprovalRequest>(`/documents/${documentId}/approvals`, data),
+    getRequest: (documentId: number, requestId: number) =>
+        api.get<ApprovalRequest>(`/documents/${documentId}/approvals/${requestId}`),
+    submitReview: (documentId: number, requestId: number, data: SubmitReviewDTO) =>
+        api.post<ApprovalRequest>(`/documents/${documentId}/approvals/${requestId}/review`, data),
+    withdraw: (documentId: number, requestId: number) => api.delete(`/documents/${documentId}/approvals/${requestId}`),
+    getMyPending: () => api.get<ApprovalRequest[]>('/approvals/pending')
 }
 
 export default api

--- a/src/stores/approvals.ts
+++ b/src/stores/approvals.ts
@@ -1,0 +1,62 @@
+import { defineStore } from 'pinia'
+import { ref } from 'vue'
+import { approvalsApi } from '@/services/api'
+import type { ApprovalRequest, CreateApprovalRequestDTO, SubmitReviewDTO } from '@/types/approval'
+
+export const useApprovalsStore = defineStore('approvals', () => {
+    const requests = ref<ApprovalRequest[]>([])
+    const pendingReviews = ref<ApprovalRequest[]>([])
+    const loading = ref(false)
+
+    async function fetchForDocument(documentId: number): Promise<ApprovalRequest[]> {
+        loading.value = true
+        try {
+            const { data } = await approvalsApi.getForDocument(documentId)
+            requests.value = data
+            return data
+        } finally {
+            loading.value = false
+        }
+    }
+
+    async function createRequest(documentId: number, data: CreateApprovalRequestDTO): Promise<ApprovalRequest> {
+        const { data: created } = await approvalsApi.create(documentId, data)
+        requests.value.push(created)
+        return created
+    }
+
+    async function submitReview(
+        documentId: number,
+        requestId: number,
+        data: SubmitReviewDTO
+    ): Promise<ApprovalRequest> {
+        const { data: updated } = await approvalsApi.submitReview(documentId, requestId, data)
+        const idx = requests.value.findIndex((r) => r.id === requestId)
+        if (idx !== -1) requests.value[idx] = updated
+        const pidx = pendingReviews.value.findIndex((r) => r.id === requestId)
+        if (pidx !== -1) pendingReviews.value.splice(pidx, 1)
+        return updated
+    }
+
+    async function withdraw(documentId: number, requestId: number): Promise<void> {
+        await approvalsApi.withdraw(documentId, requestId)
+        requests.value = requests.value.filter((r) => r.id !== requestId)
+    }
+
+    async function fetchPendingReviews(): Promise<ApprovalRequest[]> {
+        const { data } = await approvalsApi.getMyPending()
+        pendingReviews.value = data
+        return data
+    }
+
+    return {
+        requests,
+        pendingReviews,
+        loading,
+        fetchForDocument,
+        createRequest,
+        submitReview,
+        withdraw,
+        fetchPendingReviews
+    }
+})

--- a/src/stores/documents.ts
+++ b/src/stores/documents.ts
@@ -1,11 +1,15 @@
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import api from '@/services/api'
+import { documentsApi } from '@/services/api'
 import type { Document, CreateDocumentRequest, UpdateDocumentRequest } from '@/types'
+import type { DocumentVersion } from '@/types/document'
 
 export const useDocumentsStore = defineStore('documents', () => {
     const documents = ref<Document[]>([])
     const loading = ref(false)
+    const versions = ref<DocumentVersion[]>([])
+    const versionsLoading = ref(false)
 
     async function fetchDocuments(workspaceId: string): Promise<Document[]> {
         loading.value = true
@@ -36,5 +40,32 @@ export const useDocumentsStore = defineStore('documents', () => {
         documents.value = documents.value.filter((d) => d.id !== id)
     }
 
-    return { documents, loading, fetchDocuments, createDocument, updateDocument, deleteDocument }
+    async function fetchVersions(documentId: number): Promise<DocumentVersion[]> {
+        versionsLoading.value = true
+        try {
+            const { data } = await documentsApi.getVersions(documentId)
+            versions.value = data
+            return data
+        } finally {
+            versionsLoading.value = false
+        }
+    }
+
+    async function restoreVersion(documentId: number, versionId: number): Promise<void> {
+        await documentsApi.restoreVersion(documentId, versionId)
+        await fetchVersions(documentId)
+    }
+
+    return {
+        documents,
+        loading,
+        versions,
+        versionsLoading,
+        fetchDocuments,
+        createDocument,
+        updateDocument,
+        deleteDocument,
+        fetchVersions,
+        restoreVersion
+    }
 })

--- a/src/types/approval.ts
+++ b/src/types/approval.ts
@@ -1,0 +1,33 @@
+import type { UserSummary } from './collaboration'
+
+export type ApprovalStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'WITHDRAWN'
+export type ApprovalDecision = 'APPROVED' | 'REJECTED'
+
+export interface ApprovalReview {
+    id: number
+    reviewer: UserSummary
+    decision: ApprovalDecision
+    comment?: string
+    reviewedAt: string
+}
+
+export interface ApprovalRequest {
+    id: number
+    documentId: number
+    documentTitle: string
+    requestedBy: UserSummary
+    status: ApprovalStatus
+    message?: string
+    reviews: ApprovalReview[]
+    createdAt: string
+}
+
+export interface CreateApprovalRequestDTO {
+    reviewerEmails: string[]
+    message?: string
+}
+
+export interface SubmitReviewDTO {
+    decision: ApprovalDecision
+    comment?: string
+}

--- a/src/types/document.ts
+++ b/src/types/document.ts
@@ -4,13 +4,20 @@ export enum DocumentStatus {
     Archived = 'ARCHIVED'
 }
 
+export interface DocumentVersionUserSummary {
+    id: number
+    name: string
+    email: string
+}
+
 export interface DocumentVersion {
-    id: string
-    documentId: string
+    id: number
+    documentId: number
     versionNumber: number
-    content: string
+    changeNote?: string
+    createdBy: DocumentVersionUserSummary
     createdAt: string
-    createdBy: string
+    fieldValues: Record<string, string>
 }
 
 export interface Document {

--- a/src/types/generation.ts
+++ b/src/types/generation.ts
@@ -25,12 +25,15 @@ export interface GenerationRequest {
 
 export type DocumentStatus = 'DRAFT' | 'PROCESSING' | 'READY' | 'ERROR'
 
+export type DocumentApprovalStatus = 'NONE' | 'PENDING_APPROVAL' | 'APPROVED' | 'REJECTED'
+
 export interface Document {
     id: number
     name: string
     templateId: number
     templateName: string
     status: DocumentStatus
+    approvalStatus?: DocumentApprovalStatus
     createdAt: string
     updatedAt?: string
 }

--- a/src/views/approvals/PendingApprovalsView.vue
+++ b/src/views/approvals/PendingApprovalsView.vue
@@ -1,0 +1,96 @@
+<script setup lang="ts">
+import { onMounted, computed } from 'vue'
+import { useRouter } from 'vue-router'
+import { useApprovalsStore } from '@/stores/approvals'
+
+const router = useRouter()
+const approvalsStore = useApprovalsStore()
+
+const pendingReviews = computed(() => approvalsStore.pendingReviews)
+
+function formatDate(iso: string): string {
+    return new Date(iso).toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    })
+}
+
+function goToDocument(documentId: number): void {
+    router.push({ name: 'document-detail', params: { id: documentId } })
+}
+
+onMounted(() => approvalsStore.fetchPendingReviews().catch(() => {}))
+</script>
+
+<template>
+    <div class="min-h-screen bg-gray-50">
+        <div class="max-w-3xl mx-auto px-4 py-8">
+            <h1 class="text-xl font-semibold text-gray-900 mb-6">Pending Approvals</h1>
+
+            <div v-if="approvalsStore.loading" class="space-y-3">
+                <div
+                    v-for="i in 4"
+                    :key="i"
+                    class="h-16 bg-white rounded-2xl border border-gray-100 animate-pulse"
+                />
+            </div>
+
+            <div
+                v-else-if="pendingReviews.length === 0"
+                class="bg-white rounded-2xl border border-gray-100 shadow-sm p-10 text-center"
+            >
+                <svg
+                    class="w-8 h-8 mx-auto mb-3 text-gray-300"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                >
+                    <path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        stroke-width="1.5"
+                        d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                    />
+                </svg>
+                <p class="text-sm text-gray-500">
+                    No pending reviews. You're all caught up!
+                </p>
+            </div>
+
+            <div v-else class="space-y-3">
+                <button
+                    v-for="request in pendingReviews"
+                    :key="request.id"
+                    class="w-full bg-white rounded-2xl border border-gray-100 shadow-sm p-4 text-left hover:border-gray-300 transition-colors"
+                    @click="goToDocument(request.documentId)"
+                >
+                    <div class="flex items-start justify-between gap-3">
+                        <div class="min-w-0">
+                            <p class="text-sm font-semibold text-gray-900 truncate">
+                                {{ request.documentTitle }}
+                            </p>
+                            <p class="text-xs text-gray-500 mt-0.5">
+                                Requested by
+                                {{ request.requestedBy.name }}
+                                &middot;
+                                {{ formatDate(request.createdAt) }}
+                            </p>
+                            <p
+                                v-if="request.message"
+                                class="text-xs text-gray-600 mt-1 line-clamp-2"
+                            >
+                                {{ request.message }}
+                            </p>
+                        </div>
+                        <span
+                            class="text-xs font-medium px-2 py-0.5 rounded-full bg-amber-100 text-amber-700 shrink-0"
+                        >
+                            Pending
+                        </span>
+                    </div>
+                </button>
+            </div>
+        </div>
+    </div>
+</template>

--- a/src/views/documents/DocumentDetailView.vue
+++ b/src/views/documents/DocumentDetailView.vue
@@ -2,21 +2,34 @@
 import { ref, computed, onMounted, onUnmounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useGenerationStore } from '@/stores/generation'
+import { useApprovalsStore } from '@/stores/approvals'
 import GenerationStatusBanner from '@/components/GenerationStatusBanner.vue'
 import ShareModal from '@/components/ShareModal.vue'
 import CommentsPanel from '@/components/CommentsPanel.vue'
+import VersionHistoryPanel from '@/components/VersionHistoryPanel.vue'
+import ApprovalBar from '@/components/ApprovalBar.vue'
+import RequestApprovalModal from '@/components/RequestApprovalModal.vue'
+import ApprovalRequestModal from '@/components/ApprovalRequestModal.vue'
 import api from '@/services/api'
 import type { Document, FieldValue } from '@/types/generation'
 
 const route = useRoute()
 const router = useRouter()
 const generationStore = useGenerationStore()
+const approvalsStore = useApprovalsStore()
 
 const documentId = computed(() => Number(route.params.id))
 const documentIdStr = computed(() => String(route.params.id))
 
 const showShareModal = ref(false)
 const showComments = ref(false)
+const showHistory = ref(false)
+const showRequestApprovalModal = ref(false)
+const showApprovalRequestModal = ref(false)
+
+const latestApprovalRequest = computed(
+    () => approvalsStore.requests[approvalsStore.requests.length - 1] ?? null
+)
 
 const document = ref<Document | null>(null)
 const isLoading = ref(false)
@@ -124,6 +137,7 @@ function goBack(): void {
 onMounted(async () => {
     generationStore.reset()
     await Promise.all([loadDocument(), loadFieldValues()])
+    approvalsStore.fetchForDocument(documentId.value).catch(() => {})
 })
 
 onUnmounted(() => {
@@ -164,6 +178,49 @@ onUnmounted(() => {
                     <span v-if="showAutoSave" class="text-xs text-gray-400 animate-pulse">
                         Auto-saving…
                     </span>
+                    <button
+                        @click="showRequestApprovalModal = true"
+                        class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
+                    >
+                        <svg
+                            class="w-3.5 h-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                        </svg>
+                        Request Approval
+                    </button>
+                    <button
+                        @click="showHistory = !showHistory"
+                        class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border text-sm font-medium transition-colors"
+                        :class="
+                            showHistory
+                                ? 'border-gray-900 bg-gray-900 text-white'
+                                : 'border-gray-200 text-gray-700 hover:border-gray-400'
+                        "
+                    >
+                        <svg
+                            class="w-3.5 h-3.5"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                            />
+                        </svg>
+                        History
+                    </button>
                     <button
                         @click="showShareModal = true"
                         class="flex items-center gap-1.5 px-3 py-1.5 rounded-lg border border-gray-200 text-sm font-medium text-gray-700 hover:border-gray-400 transition-colors"
@@ -210,6 +267,15 @@ onUnmounted(() => {
                 </div>
             </div>
         </header>
+
+        <!-- Approval status bar -->
+        <ApprovalBar
+            v-if="document?.approvalStatus && document.approvalStatus !== 'NONE'"
+            :document-id="documentId"
+            :approval-status="document.approvalStatus"
+            @view-request="showApprovalRequestModal = true"
+            @status-changed="approvalsStore.fetchForDocument(documentId).catch(() => {})"
+        />
 
         <!-- Generation status banner -->
         <GenerationStatusBanner
@@ -436,6 +502,9 @@ onUnmounted(() => {
 
             <!-- Comments panel -->
             <CommentsPanel v-if="showComments" :document-id="documentIdStr" />
+
+            <!-- Version history panel -->
+            <VersionHistoryPanel v-if="showHistory" :document-id="documentId" />
         </div>
 
         <!-- ShareModal -->
@@ -443,6 +512,21 @@ onUnmounted(() => {
             v-if="showShareModal"
             :document-id="documentIdStr"
             @close="showShareModal = false"
+        />
+
+        <!-- Request Approval Modal -->
+        <RequestApprovalModal
+            v-if="showRequestApprovalModal"
+            :document-id="documentId"
+            @close="showRequestApprovalModal = false"
+            @submitted="approvalsStore.fetchForDocument(documentId).catch(() => {})"
+        />
+
+        <!-- Approval Request Detail Modal -->
+        <ApprovalRequestModal
+            v-if="showApprovalRequestModal && latestApprovalRequest"
+            :request="latestApprovalRequest"
+            @close="showApprovalRequestModal = false"
         />
 
         <!-- Loading skeleton -->

--- a/tasks/TODO_6_M6_VERSION_HISTORY_APPROVALS.md
+++ b/tasks/TODO_6_M6_VERSION_HISTORY_APPROVALS.md
@@ -1,0 +1,40 @@
+# TODO_6: M6 Version History & Approval Workflow UI
+
+## Feature 1: Document Version History
+
+- [x] Update `src/types/document.ts` — rewrite `DocumentVersion` to match API spec
+- [x] Update `src/services/api.ts` — add `documentsApi` with version endpoints
+- [x] Update `src/stores/documents.ts` — add `versions` state + `fetchVersions` / `restoreVersion` actions
+- [x] Create `src/components/VersionHistoryPanel.vue` — right-side collapsible panel
+- [x] Create `src/components/VersionPreviewModal.vue` — single-version read-only view
+- [x] Create `src/components/VersionCompareModal.vue` — side-by-side diff view
+- [x] Update `DocumentDetailView.vue` — "History" toggle + VersionHistoryPanel
+
+## Feature 2: Approval Workflow
+
+- [x] Create `src/types/approval.ts`
+- [x] Update `src/services/api.ts` — add `approvalsApi`
+- [x] Create `src/stores/approvals.ts`
+- [x] Create `src/components/ApprovalBar.vue` — sticky status bar
+- [x] Create `src/components/RequestApprovalModal.vue` — multi-email input
+- [x] Create `src/components/ApprovalRequestModal.vue` — full request detail
+- [x] Create `src/views/approvals/PendingApprovalsView.vue`
+- [x] Update `src/router/index.ts` — add `/approvals/pending` route
+- [x] Update `src/components/AppSidebar.vue` — add "Pending Approvals" nav item
+- [x] Update `DocumentDetailView.vue` — ApprovalBar + "Request Approval" button
+
+## Post-implementation
+
+- [x] Run type-check and fix all errors
+- [x] Run prettier
+- [x] Commit (version history) + commit (approvals)
+- [x] Open PR
+
+## Review
+
+All files implemented. Key decisions:
+- `DocumentVersion` uses numeric IDs to match `generation.ts` Document type (documentId: number)
+- `UserSummary` imported from `@/types/collaboration` (string id)
+- `approvalStatus` added to `Document` type in `generation.ts` as optional field
+- Version panel follows CommentsPanel.vue pattern (w-72, shrink-0, right side)
+- ApprovalBar uses top sticky bar pattern (above the two-panel layout)


### PR DESCRIPTION
## Summary

- Implements document version history panel with view, restore, and side-by-side compare (issues #40)
- Implements approval workflow UI with request, review, status bar, and pending reviews page (issue #42)

## Changes

### Version History
- `src/types/document.ts` — rewrote `DocumentVersion` to match API spec (numeric ids, `UserSummary`, `fieldValues`)
- `src/services/api.ts` — added `documentsApi` with version endpoints
- `src/stores/documents.ts` — added `versions` state, `fetchVersions` and `restoreVersion` actions
- `src/components/VersionHistoryPanel.vue` — right-side panel with version list, checkboxes for compare, inline restore confirmation
- `src/components/VersionPreviewModal.vue` — read-only single-version field display with restore button
- `src/components/VersionCompareModal.vue` — side-by-side diff with yellow highlight on differing fields

### Approval Workflow
- `src/types/approval.ts` — `ApprovalRequest`, `ApprovalReview`, DTOs
- `src/services/api.ts` — added `approvalsApi`
- `src/stores/approvals.ts` — full approval state + actions
- `src/components/ApprovalBar.vue` — sticky amber/green/red status bar; reviewer inline approve/reject with comment
- `src/components/RequestApprovalModal.vue` — multi-email chip input + optional message
- `src/components/ApprovalRequestModal.vue` — full request detail with review list
- `src/views/approvals/PendingApprovalsView.vue` — list of pending review requests for current user
- `src/router/index.ts` — `/approvals/pending` route
- `src/components/AppSidebar.vue` — "Pending Approvals" nav item with amber badge
- `src/views/documents/DocumentDetailView.vue` — integrated all new components

## Test plan

- [ ] Open a document detail page — verify History button toggles VersionHistoryPanel
- [ ] With versions present: View opens VersionPreviewModal, Restore shows inline confirm
- [ ] Select 2 versions via checkboxes, click Compare — side-by-side diff appears, changed fields highlighted yellow
- [ ] Request Approval button opens modal, add reviewer emails (Enter or Add button), submit
- [ ] With `approvalStatus: PENDING_APPROVAL` on document — ApprovalBar shows amber bar
- [ ] As a reviewer with pending review — Approve/Reject buttons appear with inline comment input
- [ ] Sidebar shows Pending Approvals with count badge; navigating to it lists pending requests